### PR TITLE
#137 release v0.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # calendar-widgets
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![Current bundle size: 171.23 kB](https://img.shields.io/badge/Bundle_Size-171.23_kB-green.svg)
+![Current bundle size: 32.32 kB](https://img.shields.io/badge/Bundle_Size-32.32_kB-green.svg)
 
 Working with dates sucks, working with calendars sucks even more. Here's an attempt at making things less sucky. Website: [http://www.calendar-widgets.com/](http://www.calendar-widgets.com/)
 
@@ -37,7 +37,7 @@ Once the package is installed, you'll have access to an array of helpers and uti
 ### Helpers
 - [`listCalendarYear`](https://calendar-widgets.com/helpers/listCalendarYear) function
 - [`listDaysInMonth`](https://calendar-widgets.com/helpers/listDaysInMonth) function
-- `listLocalizedMonths` function
+- `listLocalizedMonths` function `do not use`
 
 ### Utilities
 - [`formatDate`](https://calendar-widgets.com/utilities/formatDate) function

--- a/workspaces/calendar-widgets/README.md
+++ b/workspaces/calendar-widgets/README.md
@@ -1,6 +1,6 @@
 # calendar-widgets
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-![Current bundle size: 32.11 kB](https://img.shields.io/badge/Bundle_Size-32.11_kB-green.svg)
+![Current bundle size: 32.32 kB](https://img.shields.io/badge/Bundle_Size-32.32_kB-green.svg)
 
 Working with dates sucks, working with calendars sucks even more. Here's an attempt at making things less sucky. 
 
@@ -28,7 +28,8 @@ Once the package is installed, you'll have access to an array of helpers and uti
 ### Helpers
 - [`listCalendarYear`](https://calendar-widgets.com/helpers/listCalendarYear) function
 - [`listDaysInMonth`](https://calendar-widgets.com/helpers/listDaysInMonth) function
-- `listLocalizedMonths` function
+- `listLocalizedMonths` function `do not use`
+
 ### Utilities
 - [`formatDate`](https://calendar-widgets.com/utilities/formatDate) function
 - [`getDaysInMonth`](https://calendar-widgets.com/utilities/getDaysInMonth) function

--- a/workspaces/calendar-widgets/package.json
+++ b/workspaces/calendar-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar-widgets",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "./dist/bundle.js",
   "type": "module",
   "module": "./src/index.js",

--- a/workspaces/docs/docs/changelog.md
+++ b/workspaces/docs/docs/changelog.md
@@ -11,6 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## 0.0.11
+
+## Removed
+- `react` and `react-dom` from build to reduce build size and avoid conflicts with library users
+
+## Added
+- `react` and `react-dom` as peer dependencies 
+
+## Changed
+- Changed build output from `umd` to both `es` and `cjs` for React Component Development
+- Changed production build to utilize `terser` to minify code
+
 ## 0.0.10
 
 ### Changed

--- a/workspaces/tests/pnpm-lock.yaml
+++ b/workspaces/tests/pnpm-lock.yaml
@@ -1979,7 +1979,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001480
-      electron-to-chromium: 1.4.366
+      electron-to-chromium: 1.4.367
       node-releases: 2.0.10
       update-browserslist-db: 1.0.11(browserslist@4.21.5)
     dev: true
@@ -2265,8 +2265,8 @@ packages:
       webidl-conversions: 7.0.0
     dev: true
 
-  /electron-to-chromium@1.4.366:
-    resolution: {integrity: sha512-XjC4pyf1no8kJe24nUfyexpWwiGRbZWXU/KbprSEvXcTXUlr3Zr5vK3lQt2to0ttpMhAc3iENccwPSKbnEW2Fg==}
+  /electron-to-chromium@1.4.367:
+    resolution: {integrity: sha512-mNuDxb+HpLhPGUKrg0hSxbTjHWw8EziwkwlJNkFUj3W60ypigLDRVz04vU+VRsJPi8Gub+FDhYUpuTm9xiEwRQ==}
     dev: true
 
   /emittery@0.13.1:


### PR DESCRIPTION
## 0.0.11

## Removed
- `react` and `react-dom` from build to reduce build size and avoid conflicts with library users

## Added
- `react` and `react-dom` as peer dependencies 

## Changed
- Changed build output from `umd` to both `es` and `cjs` for React Component Development
- Changed production build to utilize `terser` to minify code
