### PR TITLE
#140 Include "bundle.es.js" in the "module" field of package.json

### DIFF
--- a/workspaces/calendar-widgets/package.json
+++ b/workspaces/calendar-widgets/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.11",
   "main": "./dist/bundle.js",
   "type": "module",
-  "module": "./src/index.js",
+  "module": "./dist/bundle.es.js",
   "types": "@types/calendar-widgets/index.d.ts",
   "scripts": {
     "lint": "eslint -c .eslintrc.cjs ./src --ext .ts,.tsx",

--- a/workspaces/tests/pnpm-lock.yaml
+++ b/workspaces/tests/pnpm-lock.yaml
@@ -4268,7 +4268,7 @@ packages:
     resolution: {directory: ../calendar-widgets, type: directory}
     id: file:../calendar-widgets
     name: calendar-widgets
-    version: 0.0.10
+    version: 0.0.11
     peerDependencies:
       react: 18.2.0
       react-dom: 18.2.0


### PR DESCRIPTION
Change "module" field in package.json to include "bundle.es.js"

Updated the "module" field in the package.json file from "./src/index.js" to "./dist/bundle.es.js"
This change will make it easier for users to import the ES module version of the library, as it includes the optimized "bundle.es.js" file as the entry point.
Note that this change may not affect users who are using a bundler that does not support the "module" field, as those users will continue to use the "main" field to import the library.
This change is included in version 0.0.12 of the "calendar-widgets" library.