### PR TITLE
#190 `Calendar.date` should default to today if no `date` prop is pas…

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -7,7 +7,7 @@ export default function HomePage() {
   return (
     <div className='container mx-auto max-w-7xl'>
       <div>
-        <Calendar date={new Date()} className='w-[400px] w-full' />
+        <Calendar className='w-[400px]' />
       </div>
 
       <EndlessCards cards={landingNav} />

--- a/src/react/Calendar/Calendar.tsx
+++ b/src/react/Calendar/Calendar.tsx
@@ -10,7 +10,7 @@ interface DayComponentProps {
 }
 
 const Calendar: FC<CalendarProps> = ({
-  date,
+  date = new Date(),
   dayComponent,
   showAdjacentDays = true,
   dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'],

--- a/src/react/Calendar/Calendar.types.ts
+++ b/src/react/Calendar/Calendar.types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface CalendarProps {
-  date: Date | {
+  date?: Date | {
     year: number;
     month: number;
     day: number;


### PR DESCRIPTION
…sed, `date` should be optional