### PR TITLE
#222 De-clutter Calendar, assign new prop types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "cSpell.words": [],
+  "cSpell.words": [
+    "CLASSNAME"
+  ],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,4 @@ export const ONE_HUNDRED = 100;
 export const NINETEEN_HUNDRED = 1900;
 export const TWO_THOUSAND = 2000;
 export const TWO_THOUSAND_AND_ONE_HUNDRED = 2100;
+export const BASE_CLASSNAME = 'calendar-widgets__';

--- a/src/examples/BasicCalendarV2.tsx
+++ b/src/examples/BasicCalendarV2.tsx
@@ -3,10 +3,8 @@ import { Calendar } from '../react';
 import { CustomHeaderFooterRendererProps } from '../react/Calendar/Calendar.types';
 
 const CustomDay = ({ date }: { date: Date }) => (
-  <div style={{ height: '34px', width: '14.28%', textAlign: 'center' }}>
-    <button>
-      {date.getDate()}
-    </button>
+  <div style={{ height: '34px', textAlign: 'center' }}>
+    {date.getDate()}
   </div>
 );
 
@@ -16,10 +14,14 @@ const BasicCalendarV2 = () => {
       date={new Date()}
       dayComponent={CustomDay}
       customHeader={(props: CustomHeaderFooterRendererProps) => (
-        <div style={{ width: '100%' }}>
-          <button onClick={props.handlePrevMonth}>{props.prevMonth}</button>
-          <div>{props.currentMonth}</div>
-          <button onClick={props.handleNextMonth}>{props.nextMonth}</button>
+        <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between', boxSizing: 'border-box' }}>
+          <button onClick={props.handlePrevMonth}>
+            Prev month ({props.prevMonth})
+          </button>
+          {/* <div>{props.currentDate.toLocaleDateString('en-US')}</div> */}
+          <button onClick={props.handleNextMonth}>
+            Next month ({props.nextMonth})
+          </button>
         </div>
       )}
     />

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,3 +2,4 @@ export { calculateHoursBetween } from './calculateHoursBetween';
 export { convertTimeToHours } from './convertTimeToHours';
 export { listHoursBetween } from './listHoursBetween';
 export { magicNumber } from './magicNumber';
+export { dateToNumbers } from './dateToNumbers';

--- a/src/helpers/magicNumber.ts
+++ b/src/helpers/magicNumber.ts
@@ -1,5 +1,11 @@
 import { ONE, ZERO, TEN } from '../constants';
 
+/**
+ * Converts a number string into its numeric representation.
+ *
+ * @param {string} numberString - The input number string to be converted.
+ * @returns {number} The numeric representation of the input number string.
+ */
 export const magicNumber = (numberString: string) => {
   interface Numbers {
     [key: string]: number;

--- a/src/react/Calendar/Calendar-grid.css
+++ b/src/react/Calendar/Calendar-grid.css
@@ -1,0 +1,9 @@
+.calendar-widgets__Calendar__component {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.calendar-widgets__Calendar__custom-header,
+.calendar-widgets__Calendar__custom-footer {
+  width: 100%;
+}

--- a/src/react/Calendar/Calendar.css
+++ b/src/react/Calendar/Calendar.css
@@ -1,0 +1,18 @@
+.calendar-widgets__Calendar__component {
+  box-sizing: border-box;
+}
+
+.calendar-widgets__Calendar__component {
+  width: 400px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.calendar-widgets__Calendar__day-name {
+  width: 14%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 34px;
+}

--- a/src/react/Calendar/Calendar.helpers.ts
+++ b/src/react/Calendar/Calendar.helpers.ts
@@ -1,0 +1,37 @@
+import { magicNumber as mN } from '../../helpers';
+
+/**
+ * Returns the next month given a current month.
+ * @param month The current month as a number.
+ * @returns The next month as a number.
+ */
+export const getNextMonth = (month: number) => {
+  return month === mN('12') ? mN('1') : month + mN('1');
+};
+
+/**
+ * Returns the previous month given a current month.
+ * @param month The current month as a number.
+ * @returns The previous month as a number.
+ */
+export const getPreviousMonth = (month: number) => {
+  return month === mN('1') ? mN('12') : month - mN('1');
+};
+
+/**
+ * Creates an array of weeks for the calendar.
+ * @param days - Array of days for the calendar.
+ * @returns Array of weeks for the calendar.
+ * @example
+ * const days = [null, null, null, null, null, null, null, <Day />, <Day />, <Day />
+ * const weeks = createCalendarWeeks(days);
+*/
+export const createCalendarWeeks = (days: (JSX.Element | null)[]) => {
+  const weeks = [];
+
+  for (let i = mN('0');i < days.length;i += mN('7')) {
+    weeks.push(days.slice(i, i + mN('7')));
+  }
+
+  return weeks;
+};

--- a/src/react/Calendar/Calendar.types.ts
+++ b/src/react/Calendar/Calendar.types.ts
@@ -1,14 +1,25 @@
+/** Dependencies */
 import React from 'react';
 
 export interface CustomHeaderFooterRendererProps {
-  currentMonth: number;
   handleNextMonth: () => void;
-  nextMonth: number;
   handlePrevMonth: () => void;
+  nextMonth: number;
   prevMonth: number;
+  selectedMonth: number;
+  selectedYear: number;
+  today: Date;
 }
 
-export type CustomHeaderAndFooterRenderer = ({ currentMonth, handleNextMonth, nextMonth, handlePrevMonth, prevMonth }: CustomHeaderFooterRendererProps) => React.ReactElement;
+export type CustomHeaderAndFooterRenderer = ({
+  handleNextMonth,
+  handlePrevMonth,
+  nextMonth,
+  prevMonth,
+  selectedMonth,
+  selectedYear,
+  today
+}: CustomHeaderFooterRendererProps) => React.ReactElement;
 
 export interface CalendarProps {
   date?: Date | {

--- a/src/react/Calendar/Calendar.utilities.ts
+++ b/src/react/Calendar/Calendar.utilities.ts
@@ -1,9 +1,0 @@
-import { magicNumber as mN } from '../../helpers';
-
-export const getNextMonth = (month: number) => {
-  return month === mN('12') ? mN('1') : month + mN('1');
-};
-
-export const getPreviousMonth = (month: number) => {
-  return month === mN('1') ? mN('12') : month - mN('1');
-};

--- a/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.tsx
+++ b/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.tsx
@@ -1,0 +1,20 @@
+/** React */
+import React from 'react';
+
+/** Types */
+import { BaseDayComponentProps } from './BaseDayComponent.types';
+
+/** Constants */
+import { BASE_CLASSNAME } from '../../../../constants';
+
+const baseClassName = BASE_CLASSNAME + 'Calendar__BaseDayComponent__';
+
+const BaseDayComponent = ({ date }: BaseDayComponentProps) => {
+  return (
+    <div className={baseClassName + 'base-day'}>
+      {date.getTime()}
+    </div>
+  );
+};
+
+export default BaseDayComponent;

--- a/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.types.ts
+++ b/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.types.ts
@@ -1,0 +1,4 @@
+export interface BaseDayComponentProps {
+  date: Date;
+  isCurrentDay: boolean;
+}

--- a/src/react/Calendar/components/BaseDayComponent/index.ts
+++ b/src/react/Calendar/components/BaseDayComponent/index.ts
@@ -1,0 +1,5 @@
+/** Components */
+export { default as BaseDayComponent } from './BaseDayComponent';
+
+/** Types */
+export type { BaseDayComponentProps } from './BaseDayComponent.types';

--- a/src/react/Calendar/components/index.ts
+++ b/src/react/Calendar/components/index.ts
@@ -1,0 +1,5 @@
+/** Components */
+export { BaseDayComponent } from './BaseDayComponent';
+
+/** Types */
+export type { BaseDayComponentProps } from './BaseDayComponent';

--- a/src/react/Calendar/index.ts
+++ b/src/react/Calendar/index.ts
@@ -1,2 +1,16 @@
+/** Components */
 export { default as Calendar } from './Calendar';
-export { CustomHeaderFooterRendererProps, CustomHeaderAndFooterRenderer, CalendarProps } from './Calendar.types';
+
+/** Types */
+export {
+  CustomHeaderFooterRendererProps,
+  CustomHeaderAndFooterRenderer,
+  CalendarProps
+} from './Calendar.types';
+
+/** Helpers */
+export {
+  getNextMonth,
+  getPreviousMonth,
+  createCalendarWeeks
+} from './Calendar.helpers';


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/9mbs/calendar-widgets/blob/main/CONTRIBUTING.md).
- [x] I have verified my code does what I expect it too.
- [x] **If this is a code change**: I have verified there are no linting errors, and there are no build errors.

## Motivation

We were using conditional logic within the `Calendar` component to determine if we should use a prop assigned `DayComponent` or to use the fallback `DayComponent` 

The initial motivation was to move the fallback `DayComponent` out of the `Calendar` and assign it via props.

e.g.
```jsx
import {BaseDayComponent} from './components';

const Something = ({
    dayComponent = BaseDayComponent
}) => {
// ...
```

There are some other modifications made to the `Calendar` component

- `Calendar.customHeader` - Wrapped a `div` around components if defined to ease styling.
- `Calendar.customFooter` - Wrapped a `div` around components if defined to ease styling.
- Renamed `Calendar.customHeader.currentMonth` to `Calendar.customHeader.selectedMonth` to deflect confusion
- Renamed `Calendar.customFooter.currentMonth` to `Calendar.customFooter.selectedMonth` to deflect confusion
- Added `Calendar.customHeader.selectedYear`
- Added `Calendar.customFooter.selectedYear`
- Assigned unique classNames to pre-defined components
- Added `Calendar-grid.css` to demo styling via Grid

## Related

#222 Move fallback DayComponent outside of Calendar