### PR TITLE
#227 Refactor class names to `Calendar.constants.ts`

### DIFF
--- a/src/react/Calendar/Calendar.constants.ts
+++ b/src/react/Calendar/Calendar.constants.ts
@@ -1,0 +1,12 @@
+import { BASE_CLASSNAME } from '../../constants';
+
+const baseClassName = BASE_CLASSNAME + 'Calendar__';
+
+export const classNames = {
+  componentInterface: baseClassName + 'component-interface',
+  customHeader: baseClassName + 'custom-header',
+  component: baseClassName + 'component',
+  dayName: baseClassName + 'day-name',
+  customFooter: baseClassName + 'custom-footer',
+  emptyCell: baseClassName + 'empty-cell'
+};

--- a/src/react/Calendar/Calendar.tsx
+++ b/src/react/Calendar/Calendar.tsx
@@ -12,12 +12,10 @@ import { getNextMonth, getPreviousMonth, createCalendarWeeks } from './Calendar.
 import { BaseDayComponent } from './components';
 
 /** Constants */
-import { BASE_CLASSNAME } from '../../constants';
+import { classNames } from './Calendar.constants';
 
 /** Styles */
 import './Calendar-grid.css';
-
-const baseClassName = BASE_CLASSNAME + 'Calendar__';
 
 const Calendar: FC<CalendarProps> = ({
   date = new Date(),
@@ -27,7 +25,8 @@ const Calendar: FC<CalendarProps> = ({
   className,
   customHeader,
   customFooter,
-  style
+  style,
+  customClassNames = classNames
 }) => {
   const [currentDate, setCurrentDate] = useState(date);
   const { year, month, day } = dateToNumbers(currentDate);
@@ -61,7 +60,7 @@ const Calendar: FC<CalendarProps> = ({
 
       const dayComponent = showAdjacentDays || (i > mN('0') && i <= totalDays)
         ? <DayComponent isCurrentDay={isCurrentDay} date={currentDate} />
-        : <div className={baseClassName + 'empty-cell'} />;
+        : <div className={classNames.emptyCell} />;
 
       days.push(dayComponent);
     }
@@ -83,18 +82,21 @@ const Calendar: FC<CalendarProps> = ({
   };
 
   return (
-    <div className={className ? className : baseClassName + 'component-interface'}>
+    <div
+      className={className ? className : customClassNames.componentInterface}
+      style={style}
+    >
       {customHeader && (
-        <div className={baseClassName + 'custom-header'}>
+        <div className={customClassNames.customHeader}>
           {customHeader(customHeaderFooterProps)}
         </div>
       )}
 
-      <div className={className ? className : baseClassName + 'component'}>
+      <div className={customClassNames.component}>
         {dayNames.map((dayName, idx) =>
           <div
             key={idx}
-            className={baseClassName + 'day-name'}
+            className={customClassNames.dayName}
           >
             {dayName}
           </div>
@@ -106,7 +108,7 @@ const Calendar: FC<CalendarProps> = ({
       </div>
 
       {customFooter && (
-        <div className={baseClassName + 'custom-footer'}>
+        <div className={customClassNames.customFooter}>
           {customFooter(customHeaderFooterProps)}
         </div>
       )}

--- a/src/react/Calendar/Calendar.types.ts
+++ b/src/react/Calendar/Calendar.types.ts
@@ -37,4 +37,12 @@ export interface CalendarProps {
   customHeader?: CustomHeaderAndFooterRenderer;
   customFooter?: CustomHeaderAndFooterRenderer;
   style?: React.CSSProperties;
+  customClassNames?: {
+    componentInterface?: string;
+    customHeader?: string;
+    component?: string;
+    dayName?: string;
+    customFooter?: string;
+    emptyCell?: string;
+  }
 }

--- a/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.constants.ts
+++ b/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.constants.ts
@@ -1,0 +1,7 @@
+import { BASE_CLASSNAME } from '../../../../constants';
+
+const baseClassName = BASE_CLASSNAME + 'Calendar__BaseDayComponent__';
+
+export const classNames = {
+  baseDay: baseClassName + 'base-day'
+};

--- a/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.tsx
+++ b/src/react/Calendar/components/BaseDayComponent/BaseDayComponent.tsx
@@ -5,13 +5,11 @@ import React from 'react';
 import { BaseDayComponentProps } from './BaseDayComponent.types';
 
 /** Constants */
-import { BASE_CLASSNAME } from '../../../../constants';
-
-const baseClassName = BASE_CLASSNAME + 'Calendar__BaseDayComponent__';
+import { classNames } from './BaseDayComponent.constants';
 
 const BaseDayComponent = ({ date }: BaseDayComponentProps) => {
   return (
-    <div className={baseClassName + 'base-day'}>
+    <div className={classNames.baseDay}>
       {date.getTime()}
     </div>
   );


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/9mbs/calendar-widgets/blob/main/CONTRIBUTING.md).
- [x] I have verified my code does what I expect it too.
- [x] **If this is a code change**: I have verified there are no linting errors, and there are no build errors.

## Motivation

- Moves the hard coded class names in the Calendar component to their own `.constants.ts` file
- Hard-coded values are assigned to new prop `Calendar.customClassNames` as a fallback 

## Related

#227 Refactor class names to `Calendar.constants.ts`