### PR TITLE
Breaking/rename props

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Easy-to-use, _slightly_ un-styled React-based components that provide the out-of-the-box behavior you might see in popular Calendar applications.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/9mbs/calendar-widgets/blob/v0.0.13/LICENSE)
-![Current bundle size: 8.01 kB](https://img.shields.io/badge/Bundle_Size-8.01_kB-blue.svg)
+![Current bundle size: 9.29 kB](https://img.shields.io/badge/Bundle_Size-9.29_kB-blue.svg)
 
 
 - [Documentation](https://calendar-widgets.com)

--- a/docs/docs/calendar.mdx
+++ b/docs/docs/calendar.mdx
@@ -37,38 +37,6 @@ type date = Date | {year: number, month: number, day: number};
 
 > Coming soon. This prop is not yet implemented, but will be in a future release. For now, you can define your own onChange handler by using the `customDay` prop.
 
-### `customDay` (optional)
-
-The component used to display each day in the calendar. 
-
-Default value: `BaseDayComponent`.
-
-```ts
-interface BaseDayComponentProps {
-  date: Date;
-  isCurrentDay: boolean;
-  inSelectedMonth: boolean;
-}
-
-type customDay = BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)
-```
-
-### `dayNameComponent` (optional)
-
-The component used to display each day name in the calendar. 
-
-Default value: `BaseDayNameComponent`
-
-```ts
-export interface BaseDayNameComponentProps {
-  label: string;
-  className?: string;
-  tooltip?: string;
-}
-
-type dayNameComponent = (props: BaseDayNameComponentProps) => React.ReactElement
-```
-
 ### `showAdjacentDays` (optional)
 
 Whether to display days from the previous and next months that are adjacent to the displayed month. 
@@ -97,6 +65,16 @@ Default value: `undefined`
 
 ```ts
 type dayNameToolTips = string[] | undefined;
+```
+
+### `style` (optional)
+
+An object containing the inline style of the top-level element of the calendar.
+
+Default value: `undefined`
+
+```ts
+type style = React.CSSProperties | undefined;
 ```
 
 ### `className` (optional)
@@ -161,14 +139,36 @@ type customFooter = (props: {
 }) => React.ReactElement;
 ```
 
-### `style` (optional)
+### `customDay` (optional)
 
-An object containing the inline style of the top-level element of the calendar.
+The component used to display each day in the calendar. 
 
-Default value: `undefined`
+Default value: `BaseDayComponent`.
 
 ```ts
-type style = React.CSSProperties | undefined;
+interface BaseDayComponentProps {
+  date: Date;
+  isCurrentDay: boolean;
+  inSelectedMonth: boolean;
+}
+
+type customDay = BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)
+```
+
+### `customDayName` (optional)
+
+The component used to display each day name in the calendar. 
+
+Default value: `BaseDayNameComponent`
+
+```ts
+export interface BaseDayNameComponentProps {
+  label: string;
+  className?: string;
+  tooltip?: string;
+}
+
+type customDayName = (props: BaseDayNameComponentProps) => React.ReactElement
 ```
 
 ### `customDates` (optional)

--- a/docs/docs/calendar.mdx
+++ b/docs/docs/calendar.mdx
@@ -35,9 +35,9 @@ type date = Date | {year: number, month: number, day: number};
 
 ### `onChange` (optional) ⚠️
 
-> Coming soon. This prop is not yet implemented, but will be in a future release. For now, you can define your own onChange handler by using the `dayComponent` prop.
+> Coming soon. This prop is not yet implemented, but will be in a future release. For now, you can define your own onChange handler by using the `customDay` prop.
 
-### `dayComponent` (optional)
+### `customDay` (optional)
 
 The component used to display each day in the calendar. 
 
@@ -50,7 +50,7 @@ interface BaseDayComponentProps {
   inSelectedMonth: boolean;
 }
 
-type dayComponent = BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)
+type customDay = BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)
 ```
 
 ### `dayNameComponent` (optional)

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -41,6 +41,18 @@ To begin, you'll want to add the `calendar-widgets` package to a new or existing
   </TabItem>
 </Tabs>
 
+## Examples
+To help you get started, take a look at this simple implementation of a Calendar. 
+
+```jsx
+import React from 'react';
+import { Calendar } from 'calendar-widgets';
+
+const App = () => {
+  return <Calendar />
+}
+```
+
 ## Design Principles
 
 - **Tiny learning curve.** If you're already familiar with basic React concepts such as the passing of props, you'll do great.
@@ -55,7 +67,7 @@ To begin, you'll want to add the `calendar-widgets` package to a new or existing
 
 Our focus here is to provide library-users with the bare-bones functionality needed to develop calendar and date related interfaces. With an approach like this, there is less room for us to press our opinions on your team and more room for your team to focus on what matters - _extending the components to meet a products needs._
 
-You might also consider similar services in the open source community. These libraries tend to have more bells and whistles packed into them, which of course comes at a higher learning curve.
+You could also explore comparable tools within the open source community. These libraries usually come with additional features and functionalities, though they may require a steeper learning curve.
 
 - [FullCalendar](https://fullcalendar.io/)
 - [react-big-calendar](http://jquense.github.io/react-big-calendar/)

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -200,3 +200,7 @@ ul.table-of-contents li {
     width: 260px;
   }
 }
+
+footer.theme-doc-footer.docusaurus-mt-lg {
+  padding: 0.5rem 0.75rem;
+}

--- a/src/examples/BasicCalendar.tsx
+++ b/src/examples/BasicCalendar.tsx
@@ -5,7 +5,7 @@ const BasicCalendar = () => {
   return (
     <Calendar
       date={new Date()}
-      dayComponent={({ date, isCurrentDay }: { date: Date, isCurrentDay: boolean }) => (
+      customDay={({ date, isCurrentDay }: { date: Date, isCurrentDay: boolean }) => (
         <div style={{ height: '34px', width: '14.28%', textAlign: 'center' }}>
           {date.getDate()}
           {isCurrentDay && <span style={{ color: 'red' }}>*</span>}

--- a/src/examples/BasicDraggableDay.tsx
+++ b/src/examples/BasicDraggableDay.tsx
@@ -11,7 +11,7 @@ const BasicCalendar = () => {
   return (
     <Calendar
       date={new Date()}
-      dayComponent={DayComponent}
+      customDay={DayComponent}
     />
   );
 };

--- a/src/react/Calendar/Calendar.tsx
+++ b/src/react/Calendar/Calendar.tsx
@@ -29,7 +29,7 @@ import './styles/Calendar-grid.css';
  * A customizable calendar component that displays the days of a month in a grid format.
  *
  * @param {Date | {year: number, month: number, day: number}} [date=new Date()] - The date to display in the calendar. If an object is passed, it should have year, month, and day properties.
- * @param {BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)} [dayComponent=BaseDayComponent] - The component used to display each day in the calendar.
+ * @param {BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)} [customDay=BaseDayComponent] - The component used to display each day in the calendar.
  * @param {BaseDayNameComponentProps} [dayNameComponent=BaseDayNameComponent] - The component used to display each day name in the calendar.
  * @param {boolean} [showAdjacentDays=true] - Whether to display days from the previous and next months that are adjacent to the displayed month.
  * @param {string[]} [dayNames=['S', 'M', 'T', 'W', 'T', 'F', 'S']] - An array of strings that represent the names of the days of the week. The first element represents Sunday, the second represents Monday, and so on.
@@ -51,7 +51,7 @@ import './styles/Calendar-grid.css';
 */
 const Calendar: FC<CalendarProps> = ({
   date = new Date(),
-  dayComponent = BaseDayComponent,
+  customDay = BaseDayComponent,
   dayNameComponent = BaseDayNameComponent,
   showAdjacentDays = true,
   dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
@@ -65,7 +65,7 @@ const Calendar: FC<CalendarProps> = ({
 }) => {
   const [currentDate, setCurrentDate] = useState(date);
   const { year, month, day } = dateToNumbers(currentDate);
-  const DayComponent = dayComponent;
+  const DayComponent = customDay;
   const DayNameComponent = dayNameComponent;
   const CustomHeader = customHeader || null;
   const CustomFooter = customFooter || null;
@@ -92,7 +92,7 @@ const Calendar: FC<CalendarProps> = ({
     const startWeekday = start.getDay();
     const totalDays = end.getDate();
 
-    for (let i = mN('1') - startWeekday;i <= totalDays + mN('6') - end.getDay();i += mN('1')) {
+    for (let i = mN('1') - startWeekday; i <= totalDays + mN('6') - end.getDay(); i += mN('1')) {
       const currentDate = new Date(year, start.getMonth(), i);
       const isCurrentDay = i === day;
       const inSelectedMonth = currentDate.getFullYear() === year && currentDate.getMonth() === month - mN('1');

--- a/src/react/Calendar/Calendar.tsx
+++ b/src/react/Calendar/Calendar.tsx
@@ -92,7 +92,7 @@ const Calendar: FC<CalendarProps> = ({
     const startWeekday = start.getDay();
     const totalDays = end.getDate();
 
-    for (let i = mN('1') - startWeekday; i <= totalDays + mN('6') - end.getDay(); i += mN('1')) {
+    for (let i = mN('1') - startWeekday;i <= totalDays + mN('6') - end.getDay();i += mN('1')) {
       const currentDate = new Date(year, start.getMonth(), i);
       const isCurrentDay = i === day;
       const inSelectedMonth = currentDate.getFullYear() === year && currentDate.getMonth() === month - mN('1');

--- a/src/react/Calendar/Calendar.tsx
+++ b/src/react/Calendar/Calendar.tsx
@@ -30,7 +30,7 @@ import './styles/Calendar-grid.css';
  *
  * @param {Date | {year: number, month: number, day: number}} [date=new Date()] - The date to display in the calendar. If an object is passed, it should have year, month, and day properties.
  * @param {BaseDayComponentProps | ((props: BaseDayComponentProps) => React.ReactElement)} [customDay=BaseDayComponent] - The component used to display each day in the calendar.
- * @param {BaseDayNameComponentProps} [dayNameComponent=BaseDayNameComponent] - The component used to display each day name in the calendar.
+ * @param {BaseDayNameComponentProps} [customDayName=BaseDayNameComponent] - The component used to display each day name in the calendar.
  * @param {boolean} [showAdjacentDays=true] - Whether to display days from the previous and next months that are adjacent to the displayed month.
  * @param {string[]} [dayNames=['S', 'M', 'T', 'W', 'T', 'F', 'S']] - An array of strings that represent the names of the days of the week. The first element represents Sunday, the second represents Monday, and so on.
  * @param {string[]} [dayNameToolTips] - An optional array of strings that represent the tooltips to display for each day name. If provided, it should have 7 elements in the same order as dayNames.
@@ -52,7 +52,7 @@ import './styles/Calendar-grid.css';
 const Calendar: FC<CalendarProps> = ({
   date = new Date(),
   customDay = BaseDayComponent,
-  dayNameComponent = BaseDayNameComponent,
+  customDayName = BaseDayNameComponent,
   showAdjacentDays = true,
   dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
   dayNameToolTips,
@@ -66,7 +66,7 @@ const Calendar: FC<CalendarProps> = ({
   const [currentDate, setCurrentDate] = useState(date);
   const { year, month, day } = dateToNumbers(currentDate);
   const DayComponent = customDay;
-  const DayNameComponent = dayNameComponent;
+  const DayNameComponent = customDayName;
   const CustomHeader = customHeader || null;
   const CustomFooter = customFooter || null;
 

--- a/src/react/Calendar/Calendar.types.ts
+++ b/src/react/Calendar/Calendar.types.ts
@@ -46,7 +46,7 @@ export interface CalendarProps {
     day: number;
   };
   customDay?: (props: BaseDayComponentProps) => React.ReactElement;
-  dayNameComponent?: (props: BaseDayNameComponentProps) => React.ReactElement;
+  customDayName?: (props: BaseDayNameComponentProps) => React.ReactElement;
   showAdjacentDays?: boolean;
   dayNames?: string[];
   dayNameToolTips?: string[];

--- a/src/react/Calendar/Calendar.types.ts
+++ b/src/react/Calendar/Calendar.types.ts
@@ -45,7 +45,7 @@ export interface CalendarProps {
     month: number;
     day: number;
   };
-  dayComponent?: (props: BaseDayComponentProps) => React.ReactElement;
+  customDay?: (props: BaseDayComponentProps) => React.ReactElement;
   dayNameComponent?: (props: BaseDayNameComponentProps) => React.ReactElement;
   showAdjacentDays?: boolean;
   dayNames?: string[];

--- a/src/stories/Calendar.stories.tsx
+++ b/src/stories/Calendar.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 export const Basic: StoryObj<typeof Calendar> = {
   args: {
     date: new Date(),
-    dayComponent: ({ date }) =>
+    customDay: ({ date }) =>
       <div>
         {date.getDate()}
       </div>


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/9mbs/calendar-widgets/blob/main/CONTRIBUTING.md).
- [x] I have verified my code does what I expect it too.
- [x] **If this is a code change**: I have verified there are no linting errors, and there are no build errors.

## Motivation

This MR changes: 
- Calendar prop `dayComponent` to `customDay`
- Calendar prop `dayNameComponent` to `customDayName`

## Related

#239 
#240 